### PR TITLE
chore: fix code for useUnknownInCatchVariables in ts 4.4.4

### DIFF
--- a/src/commands/analytics/app/create.ts
+++ b/src/commands/analytics/app/create.ts
@@ -133,7 +133,7 @@ export default class Create extends SfdxCommand {
           undefined,
           undefined,
           undefined,
-          e instanceof Error ? e : new Error((e && String(e)) ?? '<unknown>')
+          e instanceof Error ? e : new Error(e ? String(e) : '<unknown>')
         );
       }
       if (typeof json !== 'object') {


### PR DESCRIPTION
for the `ts-update` ciricleci job, which runs against typescript 4.4.4, where useUnknownInCatchVariables is the default.