### PR TITLE
chore: update to latest typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "@salesforce/plugin-command-reference": "^1.3.16",
     "@salesforce/prettier-config": "^0.0.2",
     "@salesforce/ts-sinon": "1.3.21",
-    "@typescript-eslint/eslint-plugin": "^4.28.1",
-    "@typescript-eslint/parser": "^4.28.1",
+    "@typescript-eslint/eslint-plugin": "5.6.0",
+    "@typescript-eslint/parser": "5.6.0",
     "chai": "^4.3.4",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.32.0",
@@ -42,7 +42,7 @@
     "shx": "0.3.3",
     "sinon": "^11.1.1",
     "ts-node": "^10.0.0",
-    "typescript": "^4.1.3"
+    "typescript": "4.5.2"
   },
   "config": {
     "commitizen": {

--- a/src/commands/analytics/app/create.ts
+++ b/src/commands/analytics/app/create.ts
@@ -107,7 +107,7 @@ export default class Create extends SfdxCommand {
     if (this.flags.templateid || this.flags.templatename) {
       const templateSvc = new WaveTemplate(this.org as Org);
       const matchedTemplate = this.flags.templateid
-        ? await templateSvc.fetch(this.flags.templateid)
+        ? await templateSvc.fetch(this.flags.templateid as string)
         : (await templateSvc.list()).find(
             template => template.name === this.flags.templatename || template.label === this.flags.templatename
           );
@@ -163,7 +163,7 @@ export default class Create extends SfdxCommand {
     const options = new StreamingClient.DefaultOptions(this.org as Org, '/event/WaveAssetEvent', message =>
       this.streamProcessor(folderId, message)
     );
-    const timeout: Duration = Duration.minutes(this.flags.wait);
+    const timeout: Duration = Duration.minutes(this.flags.wait as number);
     options.setHandshakeTimeout(timeout);
     options.setSubscribeTimeout(timeout);
     const asyncStatusClient: StreamingClient = await StreamingClient.create(options);

--- a/src/commands/analytics/app/decouple.ts
+++ b/src/commands/analytics/app/decouple.ts
@@ -39,7 +39,7 @@ export default class Decouple extends SfdxCommand {
 
   public async run() {
     const folder = new Folder(this.org as Org);
-    const folderId = await folder.decouple(this.flags.folderid, this.flags.templateid);
+    const folderId = await folder.decouple(this.flags.folderid as string, this.flags.templateid as string);
     // If error occurs here fails out in the decouple call and reports back, otherwise success
     this.ux.log(messages.getMessage('decoupleSuccess', [folderId, this.flags.templateid]));
     return folderId;

--- a/src/commands/analytics/app/delete.ts
+++ b/src/commands/analytics/app/delete.ts
@@ -51,7 +51,7 @@ export default class Delete extends SfdxCommand {
 
   private async executeCommand(): Promise<void> {
     const folder = new Folder(this.org as Org);
-    await folder.deleteFolder(this.flags.folderid);
+    await folder.deleteFolder(this.flags.folderid as string);
     this.ux.log(messages.getMessage('deleteAppSuccess', [this.flags.folderid]));
   }
 }

--- a/src/commands/analytics/app/display.ts
+++ b/src/commands/analytics/app/display.ts
@@ -68,7 +68,7 @@ export default class Display extends SfdxCommand {
 
   public async run() {
     const folder = new Folder(this.org as Org);
-    const app = await folder.fetch(this.flags.folderid, !!this.flags.applog);
+    const app = await folder.fetch(this.flags.folderid as string, !!this.flags.applog);
 
     // force:org:display does a blue chalk on the headers, so do it here, too
     this.ux.styledHeader(blue(messages.getMessage('displayDetailHeader')));

--- a/src/commands/analytics/app/update.ts
+++ b/src/commands/analytics/app/update.ts
@@ -39,7 +39,7 @@ export default class Update extends SfdxCommand {
 
   public async run() {
     const folder = new Folder(this.org as Org);
-    const waveAppId = await folder.update(this.flags.folderid, this.flags.templateid);
+    const waveAppId = await folder.update(this.flags.folderid as string, this.flags.templateid as string);
     // If error occurs here fails out in the update call and reports back, otherwise success
     this.ux.log(messages.getMessage('updateSuccess', [waveAppId]));
     return waveAppId;

--- a/src/commands/analytics/autoinstall/app/delete.ts
+++ b/src/commands/analytics/autoinstall/app/delete.ts
@@ -58,7 +58,7 @@ export default class Delete extends SfdxCommand {
 
   public async run() {
     const autoinstall = new AutoInstall(this.org as Org);
-    const autoInstallId = await autoinstall.delete(this.flags.folderid);
+    const autoInstallId = await autoinstall.delete(this.flags.folderid as string);
     if (this.flags.async || this.flags.wait <= 0) {
       this.ux.log(messages.getMessage('appDeleteRequestSuccess', [autoInstallId]));
     } else if (autoInstallId) {

--- a/src/commands/analytics/autoinstall/app/update.ts
+++ b/src/commands/analytics/autoinstall/app/update.ts
@@ -77,7 +77,7 @@ export default class Update extends SfdxCommand {
       throw new SfdxError(messages.getMessage('missingRequiredField'));
     }
     const autoinstall = new AutoInstall(this.org as Org);
-    const autoInstallId = await autoinstall.update(templateInput, this.flags.folderid);
+    const autoInstallId = await autoinstall.update(templateInput, this.flags.folderid as string);
     if (this.flags.async || this.flags.wait <= 0) {
       this.ux.log(messages.getMessage('appUpdateRequestSuccess', [autoInstallId]));
     } else if (autoInstallId) {

--- a/src/commands/analytics/autoinstall/display.ts
+++ b/src/commands/analytics/autoinstall/display.ts
@@ -68,7 +68,7 @@ export default class Display extends SfdxCommand {
 
   public async run(): Promise<AutoInstallRequestType> {
     const autoinstall = new AutoInstall(this.org as Org);
-    const autoinstallRep = await autoinstall.fetch(this.flags.autoinstallid);
+    const autoinstallRep = await autoinstall.fetch(this.flags.autoinstallid as string);
 
     // force:org:display does a blue chalk on the headers, so do it here, too
     this.ux.styledHeader(blue(messages.getMessage('displayDetailHeader')));

--- a/src/commands/analytics/dashboard/update.ts
+++ b/src/commands/analytics/dashboard/update.ts
@@ -49,7 +49,7 @@ export default class Update extends SfdxCommand {
     // -h and -r are kind of exclusive, and, in the oclif flags, you can pass in neither,
     // in which case we should should consider a missing or no -h to be the same as -r
     const historyId = (!this.flags.removecurrenthistory && (this.flags.currenthistoryid as string)) || '';
-    const id = await dashboard.updateCurrentHistoryId(this.flags.dashboardid, historyId);
+    const id = await dashboard.updateCurrentHistoryId(this.flags.dashboardid as string, historyId);
     // If error occurs here fails out in the update call and reports back, otherwise success
 
     // if we sent up an empty historyId, that's the same as -r

--- a/src/commands/analytics/dataset/display.ts
+++ b/src/commands/analytics/dataset/display.ts
@@ -62,7 +62,7 @@ export default class Display extends SfdxCommand {
       throw new SfdxError(messages.getMessage('missingRequiredField'));
     }
     const svc = new DatasetSvc((this.org as Org).getConnection());
-    const dataset = await svc.fetch(this.flags.datasetid || this.flags.datasetname);
+    const dataset = await svc.fetch((this.flags.datasetid || this.flags.datasetname) as string);
 
     // force:org:display does a blue chalk on the headers, so do it here, too
     this.ux.styledHeader(blue(messages.getMessage('displayDetailHeader')));

--- a/src/commands/analytics/dataset/rows/fetch.ts
+++ b/src/commands/analytics/dataset/rows/fetch.ts
@@ -49,7 +49,7 @@ export default class Fetch extends SfdxCommand {
     }
     const connection = (this.org as Org).getConnection();
     const svc = new DatasetSvc(connection);
-    const dataset = await svc.fetch(this.flags.datasetid || this.flags.datasetname);
+    const dataset = await svc.fetch((this.flags.datasetid || this.flags.datasetname) as string);
 
     const options = {
       ux: !this.flags.json ? this.ux : undefined,

--- a/src/commands/analytics/query.ts
+++ b/src/commands/analytics/query.ts
@@ -74,7 +74,7 @@ export default class Query extends SfdxCommand {
       throw new SfdxError(messages.getMessage('missingRequiredField'));
     }
     let queryStr = this.flags.queryfile
-      ? await fs.readFile(this.flags.queryfile, 'utf8')
+      ? await fs.readFile(this.flags.queryfile as string, 'utf8')
       : (this.flags.query as string);
 
     const querySvc = new QuerySvc((this.org as Org).getConnection());
@@ -98,7 +98,7 @@ export default class Query extends SfdxCommand {
       if (this.flags.sql) {
         queryLanguage = 'Sql';
       } else if (this.flags.queryfile) {
-        const ext = path.extname(this.flags.queryfile);
+        const ext = path.extname(this.flags.queryfile as string);
         if (ext.toLocaleLowerCase() === '.sql') {
           queryLanguage = 'Sql';
         }

--- a/src/commands/analytics/template/create.ts
+++ b/src/commands/analytics/template/create.ts
@@ -44,7 +44,7 @@ export default class Create extends SfdxCommand {
   public async run() {
     const template = new WaveTemplate(this.org as Org);
     // Create the wave template from an app/folder id
-    const waveTemplateId = await template.create(this.flags.folderid, {
+    const waveTemplateId = await template.create(this.flags.folderid as string, {
       label: this.flags.label as string | undefined,
       description: this.flags.description as string | undefined
     });

--- a/src/commands/analytics/template/list.ts
+++ b/src/commands/analytics/template/list.ts
@@ -43,7 +43,7 @@ export default class List extends SfdxCommand {
 
   public async run() {
     const wavetemplate = new WaveTemplate(this.org as Org);
-    const templates = ((await wavetemplate.list(this.flags.includembeddedtemplates)) || [])
+    const templates = ((await wavetemplate.list(!!this.flags.includembeddedtemplates)) || [])
       .filter(template => this.flags.includesalesforcetemplates || template.id?.startsWith('0Nk'))
       .map(template => ({
         name: template.name,

--- a/src/lib/analytics/request.ts
+++ b/src/lib/analytics/request.ts
@@ -66,7 +66,7 @@ export async function fetchAllPages<T>(
     if (!items || !Array.isArray(items)) {
       break;
     }
-    all.push(...items);
+    all.push(...(items as T[]));
     const nextPagePath =
       typeof getNextPagePath === 'string'
         ? (response as Record<string, unknown>)[getNextPagePath]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@salesforce/dev-config/tsconfig-strict",
   "compilerOptions": {
+    "target": "ES2019",
     "outDir": "lib",
     "rootDir": "src",
     "noImplicitAny": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,6 +859,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -925,74 +930,75 @@
   resolved "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
   integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
-"@typescript-eslint/eslint-plugin@^4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz#c045e440196ae45464e08e20c38aff5c3a825947"
-  integrity sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==
+"@typescript-eslint/eslint-plugin@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.6.0.tgz#efd8668b3d6627c46ce722c2afe813928fe120a0"
+  integrity sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.28.1"
-    "@typescript-eslint/scope-manager" "4.28.1"
-    debug "^4.3.1"
+    "@typescript-eslint/experimental-utils" "5.6.0"
+    "@typescript-eslint/scope-manager" "5.6.0"
+    debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
-    regexpp "^3.1.0"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz#3869489dcca3c18523c46018b8996e15948dbadc"
-  integrity sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==
+"@typescript-eslint/experimental-utils@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.6.0.tgz#f3a5960f2004abdcac7bb81412bafc1560841c23"
+  integrity sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==
   dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.28.1"
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/typescript-estree" "4.28.1"
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.6.0"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/typescript-estree" "5.6.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.1.tgz#5181b81658414f47291452c15bf6cd44a32f85bd"
-  integrity sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==
+"@typescript-eslint/parser@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.6.0.tgz#11677324659641400d653253c03dcfbed468d199"
+  integrity sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.28.1"
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/typescript-estree" "4.28.1"
-    debug "^4.3.1"
+    "@typescript-eslint/scope-manager" "5.6.0"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/typescript-estree" "5.6.0"
+    debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz#fd3c20627cdc12933f6d98b386940d8d0ce8a991"
-  integrity sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==
+"@typescript-eslint/scope-manager@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz#9dd7f007dc8f3a34cdff6f79f5eaab27ae05157e"
+  integrity sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/visitor-keys" "5.6.0"
 
-"@typescript-eslint/types@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.1.tgz#d0f2ecbef3684634db357b9bbfc97b94b828f83f"
-  integrity sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==
+"@typescript-eslint/types@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.6.0.tgz#745cb1b59daadcc1f32f7be95f0f68accf38afdd"
+  integrity sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==
 
-"@typescript-eslint/typescript-estree@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz#af882ae41740d1f268e38b4d0fad21e7e8d86a81"
-  integrity sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==
+"@typescript-eslint/typescript-estree@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz#dfbb19c9307fdd81bd9c650c67e8397821d7faf0"
+  integrity sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
+    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/visitor-keys" "5.6.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz#162a515ee255f18a6068edc26df793cdc1ec9157"
-  integrity sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==
+"@typescript-eslint/visitor-keys@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz#3e36509e103fe9713d8f035ac977235fd63cb6e6"
+  integrity sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    eslint-visitor-keys "^2.0.0"
+    "@typescript-eslint/types" "5.6.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -2552,6 +2558,11 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
+eslint-visitor-keys@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
+  integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
+
 eslint@^7.27.0:
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.29.0.tgz#ee2a7648f2e729485e4d0bd6383ec1deabc8b3c0"
@@ -3350,10 +3361,10 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
-  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+globby@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -3598,6 +3609,11 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+ignore@^5.1.8:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
+  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -3829,6 +3845,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -5709,6 +5732,11 @@ regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
 regextras@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/regextras/-/regextras-0.8.0.tgz#ec0f99853d4912839321172f608b544814b02217"
@@ -6786,6 +6814,11 @@ typedoc@0.18.0:
     progress "^2.0.3"
     shelljs "^0.8.4"
     typedoc-default-themes "^0.10.2"
+
+typescript@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 typescript@^4.1.3, typescript@~4.3.2:
   version "4.3.2"


### PR DESCRIPTION
### What does this PR do?
- Update to typescript 4.5.2 and typescript-eslint 5.6.0.
- Switches to `ES2019` output, since that's the max target for our minimum version of node (12)

### What issues does this PR fix or reference?
N/a