### PR TITLE
fix: update version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/analytics",
   "description": "Commands for working with Tableau CRM applications, assets, and services",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/analyticsdx-vscode/issues",
   "dependencies": {


### PR DESCRIPTION
### What does this PR do?
Manually updates the version number so the deploy to npm will work. One of the previous publish jobs failed on updating git w/ the version number so it's out-of-sync with npm.
