### PR TITLE
chore: use release context for validate-pr job [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
           filters:
             branches:
               ignore: main
+          context: release
       - release-management/test-package:
           matrix:
             parameters:


### PR DESCRIPTION
### What does this PR do?

Use the `release` context for the `validate-pr` job

### What issues does this PR fix or reference?
[skip-validate-pr]