### PR TITLE
fix: handle Skipped auto-install request status

### DIFF
--- a/messages/autoinstall.json
+++ b/messages/autoinstall.json
@@ -40,6 +40,7 @@
   "startRequestPolling": "Waiting for auto-install request [%s] to finish",
   "requestPollingTimeout": "Timeout occurred waiting for auto-install request [%s] to finish [current status: %s], try increasing --wait",
   "requestCancelled": "Auto-install request [%s] was cancelled.",
+  "requestSkipped": "Auto-install request [%s] was skipped.",
   "enableRequestSuccess": "Successfully created auto-install request [%s] to enable Analytics",
   "enableAsyncDescription": "enable asynchronously",
   "enableAsyncLongDescription": "Enable asynchronously.",

--- a/src/commands/analytics/autoinstall/app/create.ts
+++ b/src/commands/analytics/autoinstall/app/create.ts
@@ -148,6 +148,8 @@ export default class Create extends SfdxCommand {
         return finalRequest;
       } else if (status === 'cancelled') {
         throwWithData(messages.getMessage('requestCancelled', [autoInstallId]), finalRequest);
+      } else if (status === 'skipped') {
+        throwWithData(messages.getMessage('requestSkipped', [autoInstallId]), finalRequest);
       } else {
         throwWithData(messages.getMessage('appCreateFailed', [autoInstallId]), finalRequest);
       }

--- a/src/commands/analytics/autoinstall/display.ts
+++ b/src/commands/analytics/autoinstall/display.ts
@@ -32,7 +32,7 @@ function formatDate(s: string | undefined): string | undefined {
 
 function colorStatus(s: AutoInstallStatus | undefined): string | undefined {
   if (s && process.platform !== 'win32') {
-    if (s === 'Failed' || s === 'Cancelled') {
+    if (s === 'Failed' || s === 'Cancelled' || s === 'Skipped') {
       return chalk.red(s);
     } else if (s === 'Success' || s === 'New') {
       return chalk.green(s);

--- a/src/lib/analytics/autoinstall/autoinstall.ts
+++ b/src/lib/analytics/autoinstall/autoinstall.ts
@@ -13,6 +13,7 @@ export type AutoInstallStatus =
   | 'New'
   | 'Enqueued'
   | 'Cancelled'
+  | 'Skipped'
   | 'InProgress'
   | 'AppInProgress'
   | 'Success'
@@ -74,7 +75,7 @@ export type AutoInstallCreateAppConfigurationBody = {
 
 function isFinishedRequest(r: AutoInstallRequestType): boolean {
   const status = r.requestStatus?.toLocaleLowerCase();
-  return status === 'cancelled' || status === 'success' || status === 'failed';
+  return status === 'cancelled' || status === 'success' || status === 'failed' || status === 'skipped';
 }
 
 const newStatus = 'New';

--- a/test/commands/autoinstall/app/create.test.ts
+++ b/test/commands/autoinstall/app/create.test.ts
@@ -262,6 +262,28 @@ describe('analytics:autoinstall:app:create', () => {
       if (requestNum === 1) {
         return Promise.resolve(requestWithStatus('New'));
       }
+      if (requestNum === 3) {
+        return Promise.resolve(requestWithStatus('Skipped'));
+      }
+      return Promise.resolve(requestWithStatus('InProgress'));
+    })
+    .stub(UX.prototype, 'startSpinner', () => {})
+    .stub(UX.prototype, 'stopSpinner', () => {})
+    .stub(global, 'setTimeout', stubTimeout)
+    .stdout()
+    .stderr()
+    .command(['analytics:autoinstall:app:create', '-n', 'abc'])
+    .it('runs analytics:autoinstall:app:create with Skipped status', ctx => {
+      expect(ctx.stderr).to.contain(messages.getMessage('requestSkipped', ['0UZxx0000004FzkGAE']));
+    });
+
+  test
+    .withOrg({ username: 'test@org.com' }, true)
+    .withConnectionRequest(() => {
+      requestNum++;
+      if (requestNum === 1) {
+        return Promise.resolve(requestWithStatus('New'));
+      }
       return Promise.resolve(requestWithStatus('InProgress'));
     })
     .stub(UX.prototype, 'startSpinner', () => {})


### PR DESCRIPTION
### What does this PR do?

Handle the `Skipped` auto-install request status in display and app create. This can happen on app create when the org readiness check fails.

### What issues does this PR fix or reference?
@W-13927417@