### PR TITLE
fix: updating datatransformId to dataTransformId in rest call

### DIFF
--- a/src/lib/analytics/template/wavetemplate.ts
+++ b/src/lib/analytics/template/wavetemplate.ts
@@ -60,7 +60,7 @@ export default class WaveTemplate {
   ): Promise<string | undefined> {
     const opts: Record<string, unknown> = { folderSource: { id: folderid }, label, description, recipeIds };
     if (datatransformIds && this.serverVersion >= 59.0) {
-      opts.datatransformIds = datatransformIds;
+      opts.dataTransformIds = datatransformIds;
     }
 
     const body = JSON.stringify(opts);
@@ -91,7 +91,7 @@ export default class WaveTemplate {
       opts.recipeIds = recipeIds;
     }
     if (datatransformIds && this.serverVersion >= 59.0) {
-      opts.datatransformIds = datatransformIds;
+      opts.dataTransformIds = datatransformIds;
     }
 
     const body = JSON.stringify(opts);

--- a/test/commands/template/create.test.ts
+++ b/test/commands/template/create.test.ts
@@ -169,7 +169,7 @@ describe('analytics:template:create', () => {
         expect(ctx.stdout).to.contain(messages.getMessage('createSuccess', [templateId]));
         expect(requestBody, 'requestBody').to.deep.equal({
           folderSource: { id: '00lxx000000000zCAA' },
-          datatransformIds: ['1dtxxx000000001', '1dtxxx000000002']
+          dataTransformIds: ['1dtxxx000000001', '1dtxxx000000002']
         });
       }
     );
@@ -203,7 +203,7 @@ describe('analytics:template:create', () => {
         expect(requestBody, 'requestBody').to.deep.equal({
           folderSource: { id: '00lxx000000000zCAA' },
           recipeIds: ['05vxx0000004CAeAAM', '05vxx0000004CAeAAM'],
-          datatransformIds: ['1dtxxx000000001', '1dtxxx000000002']
+          dataTransformIds: ['1dtxxx000000001', '1dtxxx000000002']
         });
       }
     );

--- a/test/commands/template/update.test.ts
+++ b/test/commands/template/update.test.ts
@@ -208,7 +208,7 @@ describe('analytics:template:update', () => {
         );
         expect(requestBody, 'requestBody').to.deep.equal({
           folderSource: { id: '00lxx000000000zCAA' },
-          datatransformIds: ['1dtxxx000000001', '1dtxxx000000002']
+          dataTransformIds: ['1dtxxx000000001', '1dtxxx000000002']
         });
       }
     );
@@ -246,7 +246,7 @@ describe('analytics:template:update', () => {
         expect(requestBody, 'requestBody').to.deep.equal({
           folderSource: { id: '00lxx000000000zCAA' },
           recipeIds: ['05vxx0000004CAeAAM', '05vxx0000004CAeAAM'],
-          datatransformIds: ['1dtxxx000000001', '1dtxxx000000002']
+          dataTransformIds: ['1dtxxx000000001', '1dtxxx000000002']
         });
       }
     );


### PR DESCRIPTION
### What does this PR do?
Updates a rest call to use the correct, "dataTransformIds", attribute.

### What issues does this PR fix or reference?
@W-14417548@