### PR TITLE
fix: add back loglevel arg for sfdx compatibility

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -20,6 +20,7 @@
       "async",
       "definitionfile",
       "json",
+      "loglevel",
       "target-org",
       "templateid",
       "templatename",
@@ -32,7 +33,7 @@
     "command": "analytics:app:decouple",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["f", "o", "t"],
-    "flags": ["api-version", "folderid", "json", "target-org", "templateid"],
+    "flags": ["api-version", "folderid", "json", "loglevel", "target-org", "templateid"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -40,7 +41,7 @@
     "command": "analytics:app:delete",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["f", "o", "p"],
-    "flags": ["api-version", "folderid", "json", "noprompt", "target-org"],
+    "flags": ["api-version", "folderid", "json", "loglevel", "noprompt", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -48,7 +49,7 @@
     "command": "analytics:app:display",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["a", "f", "o"],
-    "flags": ["api-version", "applog", "folderid", "json", "target-org"],
+    "flags": ["api-version", "applog", "folderid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -56,7 +57,7 @@
     "command": "analytics:app:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["f", "o"],
-    "flags": ["api-version", "folderid", "json", "target-org"],
+    "flags": ["api-version", "folderid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -64,7 +65,7 @@
     "command": "analytics:app:update",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["a", "f", "o", "t", "v", "w"],
-    "flags": ["allevents", "api-version", "async", "folderid", "json", "target-org", "templateid", "wait"],
+    "flags": ["allevents", "api-version", "async", "folderid", "json", "loglevel", "target-org", "templateid", "wait"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -72,7 +73,7 @@
     "command": "analytics:asset:publisher:create",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "assetid", "json", "target-org"],
+    "flags": ["api-version", "assetid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -80,7 +81,7 @@
     "command": "analytics:asset:publisher:delete",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["a", "i", "o"],
-    "flags": ["api-version", "assetid", "id", "json", "target-org"],
+    "flags": ["api-version", "assetid", "id", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -88,7 +89,7 @@
     "command": "analytics:asset:publisher:deleteall",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o", "p"],
-    "flags": ["api-version", "assetid", "json", "noprompt", "target-org"],
+    "flags": ["api-version", "assetid", "json", "loglevel", "noprompt", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -96,7 +97,7 @@
     "command": "analytics:asset:publisher:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "assetid", "json", "target-org"],
+    "flags": ["api-version", "assetid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -104,7 +105,7 @@
     "command": "analytics:autoinstall:app:cancel",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "autoinstallid", "json", "target-org"],
+    "flags": ["api-version", "autoinstallid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -120,6 +121,7 @@
       "appname",
       "async",
       "json",
+      "loglevel",
       "noenqueue",
       "pollinterval",
       "target-org",
@@ -134,7 +136,7 @@
     "command": "analytics:autoinstall:app:delete",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["a", "f", "o", "p", "w"],
-    "flags": ["api-version", "async", "folderid", "json", "pollinterval", "target-org", "wait"],
+    "flags": ["api-version", "async", "folderid", "json", "loglevel", "pollinterval", "target-org", "wait"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -148,6 +150,7 @@
       "async",
       "folderid",
       "json",
+      "loglevel",
       "pollinterval",
       "target-org",
       "templateid",
@@ -161,7 +164,7 @@
     "command": "analytics:autoinstall:display",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["a", "i", "o"],
-    "flags": ["api-version", "applog", "autoinstallid", "json", "target-org"],
+    "flags": ["api-version", "applog", "autoinstallid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -169,7 +172,7 @@
     "command": "analytics:autoinstall:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o"],
-    "flags": ["api-version", "json", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -177,7 +180,7 @@
     "command": "analytics:dashboard:history:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "dashboardid", "json", "target-org"],
+    "flags": ["api-version", "dashboardid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -185,7 +188,7 @@
     "command": "analytics:dashboard:history:revert",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "l", "o", "y"],
-    "flags": ["api-version", "dashboardid", "historyid", "json", "label", "target-org"],
+    "flags": ["api-version", "dashboardid", "historyid", "json", "label", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -193,7 +196,7 @@
     "command": "analytics:dashboard:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o"],
-    "flags": ["api-version", "json", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -201,7 +204,15 @@
     "command": "analytics:dashboard:update",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o", "r", "y"],
-    "flags": ["api-version", "currenthistoryid", "dashboardid", "json", "removecurrenthistory", "target-org"],
+    "flags": [
+      "api-version",
+      "currenthistoryid",
+      "dashboardid",
+      "json",
+      "loglevel",
+      "removecurrenthistory",
+      "target-org"
+    ],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -209,7 +220,7 @@
     "command": "analytics:dataflow:history:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "dataflowid", "json", "target-org"],
+    "flags": ["api-version", "dataflowid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -217,7 +228,7 @@
     "command": "analytics:dataflow:history:revert",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "l", "o", "y"],
-    "flags": ["api-version", "dataflowid", "historyid", "json", "label", "target-org"],
+    "flags": ["api-version", "dataflowid", "historyid", "json", "label", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -225,7 +236,7 @@
     "command": "analytics:dataflow:job:display",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "dataflowjobid", "json", "target-org"],
+    "flags": ["api-version", "dataflowjobid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -233,7 +244,7 @@
     "command": "analytics:dataflow:job:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "dataflowid", "json", "target-org"],
+    "flags": ["api-version", "dataflowid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -241,7 +252,7 @@
     "command": "analytics:dataflow:job:stop",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "dataflowjobid", "json", "target-org"],
+    "flags": ["api-version", "dataflowjobid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -249,7 +260,7 @@
     "command": "analytics:dataflow:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o"],
-    "flags": ["api-version", "json", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -257,7 +268,7 @@
     "command": "analytics:dataflow:start",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "dataflowid", "json", "target-org"],
+    "flags": ["api-version", "dataflowid", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -265,7 +276,7 @@
     "command": "analytics:dataflow:update",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["f", "i", "o", "s"],
-    "flags": ["api-version", "dataflowfile", "dataflowid", "dataflowstr", "json", "target-org"],
+    "flags": ["api-version", "dataflowfile", "dataflowid", "dataflowstr", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -273,7 +284,7 @@
     "command": "analytics:dataset:display",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "n", "o"],
-    "flags": ["api-version", "datasetid", "datasetname", "json", "target-org"],
+    "flags": ["api-version", "datasetid", "datasetname", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -281,7 +292,7 @@
     "command": "analytics:dataset:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o"],
-    "flags": ["api-version", "json", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -289,7 +300,17 @@
     "command": "analytics:dataset:rows:fetch",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "n", "o", "r"],
-    "flags": ["api-version", "datasetid", "datasetname", "dryrun", "json", "limit", "resultformat", "target-org"],
+    "flags": [
+      "api-version",
+      "datasetid",
+      "datasetname",
+      "dryrun",
+      "json",
+      "limit",
+      "loglevel",
+      "resultformat",
+      "target-org"
+    ],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -297,7 +318,7 @@
     "command": "analytics:enable",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["a", "o", "p", "w"],
-    "flags": ["api-version", "async", "json", "noenqueue", "pollinterval", "target-org", "wait"],
+    "flags": ["api-version", "async", "json", "loglevel", "noenqueue", "pollinterval", "target-org", "wait"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -305,7 +326,7 @@
     "command": "analytics:lens:history:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "json", "lensid", "target-org"],
+    "flags": ["api-version", "json", "lensid", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -313,7 +334,7 @@
     "command": "analytics:lens:history:revert",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "l", "o", "y"],
-    "flags": ["api-version", "historyid", "json", "label", "lensid", "target-org"],
+    "flags": ["api-version", "historyid", "json", "label", "lensid", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -321,7 +342,7 @@
     "command": "analytics:lens:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o"],
-    "flags": ["api-version", "json", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -335,6 +356,7 @@
       "dryrun",
       "json",
       "limit",
+      "loglevel",
       "nomapnames",
       "query",
       "queryfile",
@@ -350,7 +372,7 @@
     "command": "analytics:recipe:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o"],
-    "flags": ["api-version", "json", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -358,7 +380,7 @@
     "command": "analytics:recipe:start",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "json", "recipeid", "target-org"],
+    "flags": ["api-version", "json", "loglevel", "recipeid", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -366,7 +388,17 @@
     "command": "analytics:template:create",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["d", "f", "l", "o", "r"],
-    "flags": ["api-version", "datatransformids", "description", "folderid", "json", "label", "recipeids", "target-org"],
+    "flags": [
+      "api-version",
+      "datatransformids",
+      "description",
+      "folderid",
+      "json",
+      "label",
+      "loglevel",
+      "recipeids",
+      "target-org"
+    ],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -374,7 +406,7 @@
     "command": "analytics:template:delete",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o", "p", "t"],
-    "flags": ["api-version", "decouple", "forcedelete", "json", "noprompt", "target-org", "templateid"],
+    "flags": ["api-version", "decouple", "forcedelete", "json", "loglevel", "noprompt", "target-org", "templateid"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -382,7 +414,7 @@
     "command": "analytics:template:display",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["n", "o", "t"],
-    "flags": ["api-version", "json", "target-org", "templateid", "templatename"],
+    "flags": ["api-version", "json", "loglevel", "target-org", "templateid", "templatename"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -390,7 +422,7 @@
     "command": "analytics:template:lint",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["n", "o", "t"],
-    "flags": ["api-version", "json", "target-org", "templateid", "templatename"],
+    "flags": ["api-version", "json", "loglevel", "target-org", "templateid", "templatename"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -398,7 +430,7 @@
     "command": "analytics:template:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["a", "e", "o"],
-    "flags": ["api-version", "includembeddedtemplates", "includesalesforcetemplates", "json", "target-org"],
+    "flags": ["api-version", "includembeddedtemplates", "includesalesforcetemplates", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/analytics"
   },
   {
@@ -412,6 +444,7 @@
       "datatransformids",
       "folderid",
       "json",
+      "loglevel",
       "recipeids",
       "target-org",
       "templateid",
@@ -424,7 +457,7 @@
     "command": "analytics:template:validate",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["f", "n", "o", "t"],
-    "flags": ["api-version", "json", "target-org", "templateid", "templatename", "valuesfile"],
+    "flags": ["api-version", "json", "loglevel", "target-org", "templateid", "templatename", "valuesfile"],
     "plugin": "@salesforce/analytics"
   }
 ]

--- a/src/commands/analytics/app/create.ts
+++ b/src/commands/analytics/app/create.ts
@@ -9,6 +9,7 @@ import { EOL } from 'node:os';
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -33,6 +34,7 @@ export default class Create extends SfCommand<{ id?: string; events?: StreamingR
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     definitionfile: Flags.file({

--- a/src/commands/analytics/app/decouple.ts
+++ b/src/commands/analytics/app/decouple.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Decouple extends SfCommand<string> {
   public static readonly examples = ['$ sfdx analytics:app:decouple -f folderId -t templateId'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     folderid: Flags.salesforceId({

--- a/src/commands/analytics/app/delete.ts
+++ b/src/commands/analytics/app/delete.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Delete extends SfCommand<string> {
   public static readonly examples = ['$ sfdx analytics:app:delete -f folderid'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     folderid: Flags.salesforceId({

--- a/src/commands/analytics/app/display.ts
+++ b/src/commands/analytics/app/display.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -50,6 +51,7 @@ export default class Display extends SfCommand<AppFolder> {
   public static readonly examples = ['$ sfdx analytics:app:display -f folderId -a'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     folderid: Flags.salesforceId({

--- a/src/commands/analytics/app/list.ts
+++ b/src/commands/analytics/app/list.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -36,6 +37,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:app:list'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     folderid: Flags.string({

--- a/src/commands/analytics/app/update.ts
+++ b/src/commands/analytics/app/update.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -28,6 +29,7 @@ export default class Update extends SfCommand<{ id?: string; events?: StreamingR
   public static readonly examples = ['$ sfdx analytics:app:update -f folderId -t templateId'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.string({

--- a/src/commands/analytics/asset/publisher/create.ts
+++ b/src/commands/analytics/asset/publisher/create.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Create extends SfCommand<string | undefined> {
   public static readonly examples = ['$ sfdx analytics:asset:publisher:create -i assetId'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     assetid: Flags.salesforceId({

--- a/src/commands/analytics/asset/publisher/delete.ts
+++ b/src/commands/analytics/asset/publisher/delete.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Delete extends SfCommand<void> {
   public static readonly examples = ['$ sfdx analytics:asset:publisher:delete -a assetId -i assetPublisherId'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     id: Flags.salesforceId({

--- a/src/commands/analytics/asset/publisher/deleteall.ts
+++ b/src/commands/analytics/asset/publisher/deleteall.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Deleteall extends SfCommand<string> {
   public static readonly examples = ['$ sfdx analytics:asset:publisher:deleteall -i assetId'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     assetid: Flags.salesforceId({

--- a/src/commands/analytics/asset/publisher/list.ts
+++ b/src/commands/analytics/asset/publisher/list.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -33,6 +34,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:asset:publisher:list -i assetId'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     assetid: Flags.salesforceId({

--- a/src/commands/analytics/autoinstall/app/cancel.ts
+++ b/src/commands/analytics/autoinstall/app/cancel.ts
@@ -7,6 +7,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -24,6 +25,7 @@ export default class Cancel extends SfCommand<void> {
   public static readonly examples = ['$ sfdx analytics:autoinstall:app:cancel -i id'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     autoinstallid: Flags.salesforceId({

--- a/src/commands/analytics/autoinstall/app/create.ts
+++ b/src/commands/analytics/autoinstall/app/create.ts
@@ -7,6 +7,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -37,6 +38,7 @@ export default class Create extends SfCommand<AutoInstallRequestType | { id: str
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.salesforceId({

--- a/src/commands/analytics/autoinstall/app/delete.ts
+++ b/src/commands/analytics/autoinstall/app/delete.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -31,6 +32,7 @@ export default class Delete extends SfCommand<AutoInstallRequestType | string | 
   public static readonly examples = ['$ sfdx analytics:autoinstall:app:delete -f folderid'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     folderid: Flags.salesforceId({

--- a/src/commands/analytics/autoinstall/app/update.ts
+++ b/src/commands/analytics/autoinstall/app/update.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -37,6 +38,7 @@ export default class Update extends SfCommand<AutoInstallRequestType | string | 
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.salesforceId({

--- a/src/commands/analytics/autoinstall/display.ts
+++ b/src/commands/analytics/autoinstall/display.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -54,6 +55,7 @@ export default class Display extends SfCommand<AutoInstallRequestType> {
   public static readonly examples = ['$ sfdx analytics:autoinstall:display -i id'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     autoinstallid: Flags.salesforceId({

--- a/src/commands/analytics/autoinstall/list.ts
+++ b/src/commands/analytics/autoinstall/list.ts
@@ -7,6 +7,7 @@
 
 import {
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -35,6 +36,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:autoinstall:list'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
   };

--- a/src/commands/analytics/dashboard/history/list.ts
+++ b/src/commands/analytics/dashboard/history/list.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -34,6 +35,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:dashboard:history:list --dashboardid <dashboardid>'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dashboardid: Flags.salesforceId({

--- a/src/commands/analytics/dashboard/history/revert.ts
+++ b/src/commands/analytics/dashboard/history/revert.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -26,6 +27,7 @@ export default class Revert extends SfCommand<string | undefined> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dashboardid: Flags.salesforceId({

--- a/src/commands/analytics/dashboard/list.ts
+++ b/src/commands/analytics/dashboard/list.ts
@@ -6,6 +6,7 @@
  */
 import {
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -34,6 +35,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:dashboard:list'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
   };

--- a/src/commands/analytics/dashboard/update.ts
+++ b/src/commands/analytics/dashboard/update.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -28,6 +29,7 @@ export default class Update extends SfCommand<string | undefined> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dashboardid: Flags.salesforceId({

--- a/src/commands/analytics/dataflow/history/list.ts
+++ b/src/commands/analytics/dataflow/history/list.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -28,6 +29,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:dataflow:history:list --dataflowid <dataflowid> '];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dataflowid: Flags.salesforceId({

--- a/src/commands/analytics/dataflow/history/revert.ts
+++ b/src/commands/analytics/dataflow/history/revert.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -26,6 +27,7 @@ export default class Revert extends SfCommand<string | undefined> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dataflowid: Flags.salesforceId({

--- a/src/commands/analytics/dataflow/job/display.ts
+++ b/src/commands/analytics/dataflow/job/display.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Display extends SfCommand<DataflowJobType> {
   public static readonly examples = ['$ sfdx analytics:dataflow:job:display --dataflowjobid <dataflowjobid>'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dataflowjobid: Flags.salesforceId({

--- a/src/commands/analytics/dataflow/job/list.ts
+++ b/src/commands/analytics/dataflow/job/list.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -35,6 +36,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:dataflow:job:list --dataflowid <dataflowid>'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dataflowid: Flags.salesforceId({

--- a/src/commands/analytics/dataflow/job/stop.ts
+++ b/src/commands/analytics/dataflow/job/stop.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Stop extends SfCommand<DataflowJobType> {
   public static readonly examples = ['$ sfdx analytics:dataflow:job:stop --dataflowjobid <dataflowjobid>'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dataflowjobid: Flags.salesforceId({

--- a/src/commands/analytics/dataflow/list.ts
+++ b/src/commands/analytics/dataflow/list.ts
@@ -7,6 +7,7 @@
 
 import {
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -27,6 +28,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:dataflow:list'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
   };

--- a/src/commands/analytics/dataflow/start.ts
+++ b/src/commands/analytics/dataflow/start.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Start extends SfCommand<DataflowJobType> {
   public static readonly examples = ['$ sfdx analytics:dataflow:start --dataflowid <dataflowid>'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dataflowid: Flags.salesforceId({

--- a/src/commands/analytics/dataflow/update.ts
+++ b/src/commands/analytics/dataflow/update.ts
@@ -7,6 +7,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -26,6 +27,7 @@ export default class Update extends SfCommand<DataflowType> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     dataflowid: Flags.salesforceId({

--- a/src/commands/analytics/dataset/display.ts
+++ b/src/commands/analytics/dataset/display.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -41,6 +42,7 @@ export default class Display extends SfCommand<DatasetType> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     datasetid: Flags.salesforceId({

--- a/src/commands/analytics/dataset/list.ts
+++ b/src/commands/analytics/dataset/list.ts
@@ -7,6 +7,7 @@
 
 import {
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -33,6 +34,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:dataset:list'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
   };

--- a/src/commands/analytics/dataset/rows/fetch.ts
+++ b/src/commands/analytics/dataset/rows/fetch.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -34,6 +35,7 @@ export default class Fetch extends SfCommand<QueryResponse | undefined> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     datasetid: Flags.salesforceId({

--- a/src/commands/analytics/enable.ts
+++ b/src/commands/analytics/enable.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -31,6 +32,7 @@ export default class Enable extends SfCommand<AutoInstallRequestType | string | 
   public static readonly examples = ['$ sfdx analytics:enable'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     async: Flags.boolean({

--- a/src/commands/analytics/lens/history/list.ts
+++ b/src/commands/analytics/lens/history/list.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -28,6 +29,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:lens:history:list --lensid <lensid> '];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     lensid: Flags.salesforceId({

--- a/src/commands/analytics/lens/history/revert.ts
+++ b/src/commands/analytics/lens/history/revert.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -26,6 +27,7 @@ export default class Revert extends SfCommand<string | undefined> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     lensid: Flags.salesforceId({

--- a/src/commands/analytics/lens/list.ts
+++ b/src/commands/analytics/lens/list.ts
@@ -7,6 +7,7 @@
 
 import {
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -27,6 +28,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:lens:list'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
   };

--- a/src/commands/analytics/query.ts
+++ b/src/commands/analytics/query.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -37,6 +38,7 @@ export default class Query extends SfCommand<QueryResponse | undefined> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     queryfile: Flags.file({

--- a/src/commands/analytics/recipe/list.ts
+++ b/src/commands/analytics/recipe/list.ts
@@ -6,6 +6,7 @@
  */
 import {
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -32,6 +33,7 @@ export default class List extends SfCommand<
   public static readonly examples = ['$ sfdx analytics:recipe:list'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
   };

--- a/src/commands/analytics/recipe/start.ts
+++ b/src/commands/analytics/recipe/start.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -25,6 +26,7 @@ export default class Start extends SfCommand<RecipeType | undefined> {
   public static readonly examples = ['$ sfdx analytics:recipe:start --recipeid <recipeid>'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     recipeid: Flags.salesforceId({

--- a/src/commands/analytics/template/create.ts
+++ b/src/commands/analytics/template/create.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -29,6 +30,7 @@ export default class Create extends SfCommand<string | undefined> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     folderid: Flags.salesforceId({

--- a/src/commands/analytics/template/delete.ts
+++ b/src/commands/analytics/template/delete.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -26,6 +27,7 @@ export default class Delete extends SfCommand<string | undefined> {
   public static readonly examples = ['$ sfdx analytics:template:delete -t templateid'];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.salesforceId({

--- a/src/commands/analytics/template/display.ts
+++ b/src/commands/analytics/template/display.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -29,6 +30,7 @@ export default class Display extends SfCommand<TemplateType> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.salesforceId({

--- a/src/commands/analytics/template/lint.ts
+++ b/src/commands/analytics/template/lint.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -29,6 +30,7 @@ export default class Lint extends SfCommand<LintType | string> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.string({

--- a/src/commands/analytics/template/list.ts
+++ b/src/commands/analytics/template/list.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -40,6 +41,7 @@ export default class List extends SfCommand<TemplateInfo[]> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     includesalesforcetemplates: Flags.boolean({

--- a/src/commands/analytics/template/update.ts
+++ b/src/commands/analytics/template/update.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -32,6 +33,7 @@ export default class Update extends SfCommand<
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.salesforceId({

--- a/src/commands/analytics/template/validate.ts
+++ b/src/commands/analytics/template/validate.ts
@@ -8,6 +8,7 @@
 import {
   Flags,
   SfCommand,
+  loglevel,
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
@@ -29,6 +30,7 @@ export default class Validate extends SfCommand<ValidateType | string> {
   ];
 
   public static readonly flags = {
+    loglevel,
     'target-org': requiredOrgFlagWithDeprecations,
     'api-version': orgApiVersionFlagWithDeprecations,
     templateid: Flags.string({

--- a/src/lib/analytics/app/folder.ts
+++ b/src/lib/analytics/app/folder.ts
@@ -72,9 +72,17 @@ export default class Folder {
   public async create(body: CreateAppBody): Promise<string | undefined> {
     if (this.serverVersion >= 55.0 && body.templateSourceId) {
       if (!body.templateOptions) {
-        body.templateOptions = { dynamicOptions: { productionType: 'ATF_3_0', runtimeLogEntryLevel: 'Warning' } };
+        // eslint-disable-next-line no-param-reassign
+        body = {
+          ...body,
+          templateOptions: { dynamicOptions: { productionType: 'ATF_3_0', runtimeLogEntryLevel: 'Warning' } },
+        };
       } else if (!body.templateOptions.dynamicOptions) {
-        body.templateOptions.dynamicOptions = { productionType: 'ATF_3_0', runtimeLogEntryLevel: 'Warning' };
+        // eslint-disable-next-line no-param-reassign
+        body.templateOptions = {
+          ...body.templateOptions,
+          dynamicOptions: { productionType: 'ATF_3_0', runtimeLogEntryLevel: 'Warning' },
+        };
       }
     }
     const response = await connectRequest<AppFolder>(this.connection, {

--- a/src/lib/analytics/query/query.ts
+++ b/src/lib/analytics/query/query.ts
@@ -307,6 +307,7 @@ export default class QuerySvc {
           ux.table(
             records,
             columnNames.reduce<Ux.Table.Columns<Row>>((all, name) => {
+              // eslint-disable-next-line no-param-reassign
               all[name] = { header: name, get: (row) => convertRowValue(row[name]) };
               return all;
             }, {})

--- a/src/lib/analytics/utils.ts
+++ b/src/lib/analytics/utils.ts
@@ -63,6 +63,7 @@ export function generateTableColumns<R extends Ux.Table.Data>(
     if (mutute) {
       column = mutute(key, column);
     }
+    // eslint-disable-next-line no-param-reassign
     columns[key] = column;
     return columns;
   }, {});

--- a/test/.eslintrc.cjs
+++ b/test/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
   rules: {
     // Allow assert style expressions. i.e. expect(true).to.be.true
     'no-unused-expressions': 'off',
+    'no-param-reassign': 'off',
     'mocha/no-identical-title': 'error',
 
     // Return types are defined by the source code. Allows for quick overwrites.

--- a/test/commands/app/list.test.ts
+++ b/test/commands/app/list.test.ts
@@ -35,11 +35,11 @@ describe('analytics:app:list', () => {
     $$.restore();
   });
 
-  it(`runs: --folderid ${folderId} (no results)`, async () => {
+  it(`runs: --folderid ${folderId} --loglevel debug (no results)`, async () => {
     await stubDefaultOrg($$, testOrg);
     $$.fakeConnectionRequest = () => Promise.resolve({ folders: [] });
 
-    await List.run(['--folderid', folderId]);
+    await List.run(['--folderid', folderId, '--loglevel', 'debug']);
     const stdout = getStdout(sfCommandStubs);
     expect(stdout, 'stdout').to.contain(messages.getMessage('noResultsFound'));
     expect(getTableData(sfCommandStubs).data, 'table').to.be.undefined;

--- a/test/commands/template/list.test.ts
+++ b/test/commands/template/list.test.ts
@@ -56,6 +56,15 @@ describe('analytics:template:list', () => {
     });
   });
 
+  it('runs with --loglevel', async () => {
+    await runAndVerify(['--loglevel=fatal'], templateValues, () => {
+      expect(getStyledHeaders(sfCommandStubs), 'headers').to.contain(messages.getMessage('templatesFound', [1]));
+      const { data } = getTableData(sfCommandStubs);
+      expectToHaveElementValue(data, templateValues[0].name, 'table');
+      expectToHaveElementValue(data, templateValues[0].label, 'table');
+    });
+  });
+
   it('runs: --includesalesforcetemplates', async () => {
     await runAndVerify(['--includesalesforcetemplates'], templateValues, () => {
       expect(getStyledHeaders(sfCommandStubs), 'headers').to.contain(messages.getMessage('templatesFound', [2]));


### PR DESCRIPTION
### What does this PR do?
Adds back the `--loglevel` arg for sfdx compatibility. It no longer does anything and prints out an appropriate warning, but the commands won't fail any longer if it's specified. We need this for existing commands that folks might already be using, but we won't be adding it to any new commands in the future.

### What issues does this PR fix or reference?
@W-15715577@
Part of the fix for [forcedotcom/analyticsdx-vscode/issues/175](https://github.com/forcedotcom/analyticsdx-vscode/issues/175)
